### PR TITLE
Add database methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 API Overview and Tasks.md
 Database Overview and Tasks.md
 .DS_Store
-/node_modules
+/node_modules/*
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ API Overview and Tasks.md
 Database Overview and Tasks.md
 .DS_Store
 /node_modules
+.env

--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ app.use('/products', productsRouter);
 app.use('/orders', ordersRouter);
 
 
-app.get('/test', async (req, res) => {
+app.get('/test', (req, res) => {
     res.json('test ok')
 })
 

--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const app = express();
 require('dotenv').config();
 const PORT = process.env.PORT;
+const query = require('./database/index');
 
 
 const accountsRouter = require('./routers/accountsRouter');
@@ -17,8 +18,9 @@ app.use('/products', productsRouter);
 app.use('/orders', ordersRouter);
 
 
-app.get('/test', (req, res) => {
-    res.json('test ok');
+app.get('/test', async (req, res) => {
+    const database = await query('SELECT NOW()');
+    res.json(`test ok - ${database.rows[0].now}`);
 })
 
 app.listen(PORT, () => {

--- a/app.js
+++ b/app.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const app = express();
-const PORT = '8080';
+require('dotenv').config();
+const PORT = process.env.PORT;
+
 
 const accountsRouter = require('./routers/accountsRouter');
 const usersRouter = require('./routers/usersRouter');

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ const app = express();
 require('dotenv').config();
 const PORT = process.env.PORT;
 const query = require('./database/index');
+const db = require('./database/db');
 
 
 const accountsRouter = require('./routers/accountsRouter');
@@ -19,8 +20,28 @@ app.use('/orders', ordersRouter);
 
 
 app.get('/test', async (req, res) => {
+    const date = new Date();
     const database = await query('SELECT NOW()');
-    res.json(`test ok - ${database.rows[0].now}`);
+    const addUserInstance = await db.addInstance('users', {
+        id: 999,
+        username: 'test_user_9999',
+        password: "ffffffffff",
+        first_name: 'test',
+        last_name: 'user',
+        street_address: '123 Anystreet',
+        city: 'Anytown',
+        state: 'USA',
+        zip: 99999,
+        date_created: date.toString(),
+        isAdmin: true
+    })
+    const allInstances = await db.getAllInstances('products');
+    res.json({
+        test: 'test ok',
+        databaseTime: `${database.rows[0].now}`,
+        dbTestAllInstances: `${allInstances.rows}`,
+        dbTestInstanceById: `${addUserInstance.rows}`
+    });
 })
 
 app.listen(PORT, () => {

--- a/app.js
+++ b/app.js
@@ -20,28 +20,7 @@ app.use('/orders', ordersRouter);
 
 
 app.get('/test', async (req, res) => {
-    const date = new Date();
-    const database = await query('SELECT NOW()');
-    const addUserInstance = await db.addInstance('users', {
-        id: 999,
-        username: 'test_user_9999',
-        password: "ffffffffff",
-        first_name: 'test',
-        last_name: 'user',
-        street_address: '123 Anystreet',
-        city: 'Anytown',
-        state: 'USA',
-        zip: 99999,
-        date_created: date.toString(),
-        isAdmin: true
-    })
-    const allInstances = await db.getAllInstances('products');
-    res.json({
-        test: 'test ok',
-        databaseTime: `${database.rows[0].now}`,
-        dbTestAllInstances: `${allInstances.rows}`,
-        dbTestInstanceById: `${addUserInstance.rows}`
-    });
+    res.json('test ok')
 })
 
 app.listen(PORT, () => {

--- a/database/db.js
+++ b/database/db.js
@@ -14,7 +14,9 @@ const getAllInstances = async (type) => {
 const getInstanceById = async (type, id) => {
     const text = `SELECT * FROM ${type} WHERE ${getIdString(type)} = ${id}`
     const response = await query(text)
-    return response;
+    const instance = response.rows[0];
+    if (!instance) return {};
+    return instance;
 }
 
 const addInstance = async (type, model) => {
@@ -41,8 +43,17 @@ const updateInstanceById = async (type, id, model) => {
     return response;
 }
 
-const removeInstanceById = async (type, id) => {
-    const text = `DELETE FROM ${type} WHERE ${getIdString(type)} = ${id}`
+const removeInstanceById = async (type, id, secondaryId) => {
+    let text;
+    if (type == 'products_orders') {
+        text = `DELETE FROM ${type} WHERE product_id = '${id}' AND order_number = ${secondaryId}`
+    } else if (type == 'products_carts') {
+        text = `DELETE FROM ${type} WHERE product_id = '${id}' AND cart_id = ${secondaryId}`
+    } else if (type == 'products') {
+        text = `DELETE FROM ${type} WHERE id = '${id}'`
+    } else {
+        text = `DELETE FROM ${type} WHERE ${getIdString(type)} = ${id}`
+    }
     const response = await query(text);
     return response;
 }
@@ -52,6 +63,5 @@ module.exports = {
     getAllInstances,
     addInstance,
     updateInstanceById,
-    removeInstanceById,
-    getIdString
+    removeInstanceById
 }

--- a/database/db.js
+++ b/database/db.js
@@ -2,7 +2,8 @@ const query = require('./index');
 const {
     getIdString,
     modelSchema,
-    formatValues
+    formatValues,
+    createWhereClause
 } = require('./util')
 
 const getAllInstances = async (type) => {
@@ -11,8 +12,10 @@ const getAllInstances = async (type) => {
     return response;
 }
     
-const getInstanceById = async (type, id) => {
-    const text = `SELECT * FROM ${type} WHERE ${getIdString(type)} = ${id}`
+const getInstanceById = async (type, id, secondaryId) => {
+    
+    const text = `SELECT * FROM ${type} WHERE ${createWhereClause(type, id, secondaryId)}`
+
     const response = await query(text)
     const instance = response.rows[0];
     if (!instance) return {};
@@ -38,22 +41,13 @@ const updateInstanceById = async (type, id, model) => {
         }
     })
     const setString = setArr.join();
-    const text = `UPDATE table_name SET ${setString} WHERE ${getIdString(type)} = ${id}`
+    const text = `UPDATE table_name SET ${setString} WHERE ${createWhereClause(type, id)}`
     const response = await query(text);
     return response;
 }
 
 const removeInstanceById = async (type, id, secondaryId) => {
-    let text;
-    if (type == 'products_orders') {
-        text = `DELETE FROM ${type} WHERE product_id = '${id}' AND order_number = ${secondaryId}`
-    } else if (type == 'products_carts') {
-        text = `DELETE FROM ${type} WHERE product_id = '${id}' AND cart_id = ${secondaryId}`
-    } else if (type == 'products') {
-        text = `DELETE FROM ${type} WHERE id = '${id}'`
-    } else {
-        text = `DELETE FROM ${type} WHERE ${getIdString(type)} = ${id}`
-    }
+    const text = `DELETE FROM ${type} WHERE ${createWhereClause(type, id, secondaryId)}`
     const response = await query(text);
     return response;
 }

--- a/database/db.js
+++ b/database/db.js
@@ -1,28 +1,50 @@
 const query = require('./index');
+const {
+    getIdString,
+    modelSchema,
+    formatValues
+} = require('./util')
 
-
-const getInstanceById = (type, id) => {
-    console.log('on');
+const getAllInstances = async (type) => {
+    const text = `SELECT * FROM ${type}`
+    const response = await query(text);
+    return response;
 }
     
-const getAllInstances = (type, id) => {
-    console.log('on');    
-}
-    
-const addInstance = (type, model) => {
-    console.log('on');
+const getInstanceById = async (type, id) => {
+    const text = `SELECT * FROM ${type} WHERE ${getIdString(type)} = ${id}`
+    const response = await query(text)
+    return response;
 }
 
-const updateInstanceById = (type, id, model) => {
-    console.log('on');
+const addInstance = async (type, model) => {
+    const schema = modelSchema[type];
+    const values = formatValues(type, model);
+    const text = `INSERT INTO ${type} (${schema}) VALUES (${values})`;
+    return response = await query(text);
 }
 
-const removeInstanceById = (type, id) => {
-    console.log('on');
+const updateInstanceById = async (type, id, model) => {
+    const schemaArr = modelSchema[type].split(', ');
+    let setArr = []
+    schemaArr.forEach((col, index) => {
+        let value = model.value
+        if (index == schemaArr.length - 1) {
+            setArr.push(`${col} = ${value}`)
+        } else {
+            setArr.push(`${col} = ${value}, `)
+        }
+    })
+    const setString = setArr.join();
+    const text = `UPDATE table_name SET ${setString} WHERE ${getIdString(type)} = ${id}`
+    const response = await query(text);
+    return response;
 }
 
-const removeAllInstances = (type) => {
-    console.log('on');
+const removeInstanceById = async (type, id) => {
+    const text = `DELETE FROM ${type} WHERE ${getIdString(type)} = ${id}`
+    const response = await query(text);
+    return response;
 }
 
 module.exports = {
@@ -31,5 +53,5 @@ module.exports = {
     addInstance,
     updateInstanceById,
     removeInstanceById,
-    removeAllInstances
+    getIdString
 }

--- a/database/db.js
+++ b/database/db.js
@@ -32,17 +32,21 @@ const updateInstanceById = async (type, id, model) => {
     const schemaArr = modelSchema[type].split(', ');
     let setArr = []
     schemaArr.forEach((col, index) => {
-        let value = model.value
+        let value = model[col];
+        if (typeof value == 'string') value = `'${value}'`
         if (index == schemaArr.length - 1) {
             setArr.push(`${col} = ${value}`)
         } else {
-            setArr.push(`${col} = ${value}, `)
+            setArr.push(`${col} = ${value},`)
         }
     })
-    const setString = setArr.join();
-    const text = `UPDATE table_name SET ${setString} WHERE ${createWhereClause(type, id)}`
+
+    const setString = setArr.join(' ')
+    const text = `UPDATE ${type} SET ${setString} WHERE ${createWhereClause(type, id)}`
     const response = await query(text);
-    return response;
+    const instance = getInstanceById(type, id);
+    if (!instance) return {};
+    return instance;
 }
 
 const removeInstanceById = async (type, id, secondaryId) => {

--- a/database/db.js
+++ b/database/db.js
@@ -15,7 +15,6 @@ const getAllInstances = async (type) => {
 const getInstanceById = async (type, id, secondaryId) => {
     
     const text = `SELECT * FROM ${type} WHERE ${createWhereClause(type, id, secondaryId)}`
-
     const response = await query(text)
     const instance = response.rows[0];
     if (!instance) return {};

--- a/database/db.js
+++ b/database/db.js
@@ -16,11 +16,13 @@ const getInstanceById = async (type, id, secondaryId) => {
     let text;
     if (type == 'carts') {
         text = `SELECT * FROM products_carts JOIN products ON products.id = products_carts.product_id JOIN carts ON carts.id = products_carts.cart_id WHERE carts.id = ${id};`
+    } else if (type == 'orders') {
+        text = `SELECT * FROM products_orders JOIN products ON products.id = products_orders.product_id JOIN orders ON orders.number = products_orders.order_number WHERE orders.number = ${id};`
     } else {
         text = `SELECT * FROM ${type} WHERE ${createWhereClause(type, id, secondaryId)}`
     }
     const response = await query(text)
-    // if (type == 'carts') return response.rows;
+    if (type == 'carts' || type == 'orders') return response.rows;
     const instance = response.rows[0];
     if (!instance) return {};
     return instance;

--- a/database/db.js
+++ b/database/db.js
@@ -1,0 +1,35 @@
+const query = require('./index');
+
+
+const getInstanceById = (type, id) => {
+    console.log('on');
+}
+    
+const getAllInstances = (type, id) => {
+    console.log('on');    
+}
+    
+const addInstance = (type, model) => {
+    console.log('on');
+}
+
+const updateInstanceById = (type, id, model) => {
+    console.log('on');
+}
+
+const removeInstanceById = (type, id) => {
+    console.log('on');
+}
+
+const removeAllInstances = (type) => {
+    console.log('on');
+}
+
+module.exports = {
+    getInstanceById,
+    getAllInstances,
+    addInstance,
+    updateInstanceById,
+    removeInstanceById,
+    removeAllInstances
+}

--- a/database/db.js
+++ b/database/db.js
@@ -13,9 +13,14 @@ const getAllInstances = async (type) => {
 }
     
 const getInstanceById = async (type, id, secondaryId) => {
-    
-    const text = `SELECT * FROM ${type} WHERE ${createWhereClause(type, id, secondaryId)}`
+    let text;
+    if (type == 'carts') {
+        text = `SELECT * FROM products_carts JOIN products ON products.id = products_carts.product_id JOIN carts ON carts.id = products_carts.cart_id WHERE carts.id = ${id};`
+    } else {
+        text = `SELECT * FROM ${type} WHERE ${createWhereClause(type, id, secondaryId)}`
+    }
     const response = await query(text)
+    // if (type == 'carts') return response.rows;
     const instance = response.rows[0];
     if (!instance) return {};
     return instance;

--- a/database/db.test.js
+++ b/database/db.test.js
@@ -257,6 +257,35 @@ describe('db', () => {
         })
     })
 
+    describe('updateInstanceById', () => {
+        it('edits a user record', async () => {
+            const type = 'users'
+            const id = 999
+            const model = userModel
+            const expected = 'edited';
+
+            model.first_name = 'edited'
+
+            const response = await db.updateInstanceById(type, id, model);
+            const actual = response.first_name;
+    
+            assert.equal(actual, expected);
+        })
+        it('edits a product record', async () => {
+            const type = 'products'
+            const id = '999'
+            const model = productModel
+            const expected = 'edited';
+
+            model.name = 'edited'
+
+            const response = await db.updateInstanceById(type, id, model);
+            const actual = response.name;
+    
+            assert.equal(actual, expected);
+        })
+    })
+
     describe('removeInstanceById', async () => {
         it('removes a product_order with two matching ids', async () => {
             const type = 'products_orders'

--- a/database/db.test.js
+++ b/database/db.test.js
@@ -197,17 +197,64 @@ describe('db', () => {
             
             assert.equal(expected, actual);
         })
-        // it('retrieves a product from the database with a matching id', async () => {
-        //     const type = 'products'
-        //     const id = '999'
-        //     const expected = '999'
+        it('retrieves a product from the database with a matching id', async () => {
+            const type = 'products'
+            const id = '999'
+            const expected = '999'
 
-        //     const response = await db.getInstanceById(type, id);
-        //     const actual = response.id;
+            const response = await db.getInstanceById(type, id);
+            const actual = response.id;
             
-        //     assert.equal(expected, actual);
-        // })
+            assert.equal(expected, actual);
+        })
+        it('retrieves a cart from the database with a matching id', async () => {
+            const type = 'carts'
+            const id = 999
+            const expected = 999
 
+            const response = await db.getInstanceById(type, id);
+            const actual = response.id;
+            
+            assert.equal(expected, actual);
+        })
+        it('retrieves an order from the database with a matching id', async () => {
+            const type = 'orders'
+            const id = 999
+            const expected = 999
+
+            const response = await db.getInstanceById(type, id);
+            const actual = response.number;
+            
+            assert.equal(expected, actual);
+        })
+        it('retrieves a products_carts row from the database with two a matching ids', async () => {
+            const type = 'products_carts'
+            const id = '999'
+            const secondaryId = 999
+            const productExpected = '999'
+            const cartExpected = 999
+
+            const response = await db.getInstanceById(type, id, secondaryId);
+            const productActual = response.product_id;
+            const cartActual = response.cart_id;
+            
+            assert.equal(productActual, productExpected);
+            assert.equal(cartActual, cartExpected);
+        })
+        it('retrieves a products_orders row from the database with two a matching ids', async () => {
+            const type = 'products_orders'
+            const id = '999'
+            const secondaryId = 999
+            const productExpected = '999'
+            const orderExpected = 999
+
+            const response = await db.getInstanceById(type, id, secondaryId);
+            const productActual = response.product_id;
+            const orderActual = response.order_number;
+            
+            assert.equal(productActual, productExpected);
+            assert.equal(orderActual, orderExpected);
+        })
     })
 
     describe('removeInstanceById', async () => {

--- a/database/db.test.js
+++ b/database/db.test.js
@@ -1,0 +1,124 @@
+const assert = require('assert');
+const db = require('./db');
+const query = require('./index.js');
+const util = require('./util.js');
+const formatDate = require('date-format');
+
+const date = new Date(2000, 1, 1, 1, 1, 1);
+const formattedDate = formatDate(date);
+const userModel = {
+    id: 999,
+    username: 'test_user_9999',
+    password: "ffffffffff",
+    first_name: 'test',
+    last_name: 'user',
+    street_address: '123 Anystreet',
+    city: 'Anytown',
+    state: 'USA',
+    zip: 99999,
+    date_created: formattedDate,
+    isAdmin: true
+}
+const productModel = {
+    id: 999,
+    name: 'Test Product',
+    img_path: '/test/path',
+    description: 'This is a description of a product.'
+}
+
+describe('query', () => {
+    it('connects to the database', async () => {
+        const databaseConnected = await query('SELECT NOW()');
+        assert.ok(databaseConnected);
+    })
+})
+
+describe('util', () => {
+    describe('getIdString', () => {
+
+        it('returns number if given an orders type', () => {
+            const type = 'orders';
+            const expected = 'number';
+
+            const actual = db.getIdString(type);
+
+            assert.ok(expected == actual);
+        })
+
+        it('returns id if given any other type', () => {
+            const type1 = 'another value';
+            const type2 = 'cart';
+            const expected = 'id';
+
+            const actual1 = util.getIdString(type1)
+            const actual2 = util.getIdString(type2)
+
+            assert.equal(expected, actual1);
+            assert.equal(expected, actual2);
+        })
+
+    })
+
+    describe('formatValues', () => {
+
+        it('formats a users type into valid SQL values', () => {
+            const type = 'users'
+            const model = userModel;
+            const expected = "999, 'test_user_9999', 'ffffffffff', 'test', 'user', '123 Anystreet', 'Anytown', 'USA', 99999, '2000-02-01T01:01:01.000', true"
+
+            const actual = util.formatValues(type, model);
+
+            assert.equal(expected, actual);
+        })
+
+        it('formats a products type into valid SQL values', () => {
+            const type = 'products'
+            const model = productModel;
+            const expected = "999, 'Test Product', '/test/path', 'This is a description of a product.'"
+            
+            const actual = util.formatValues(type, model);
+
+            assert.equal(expected, actual);
+        })
+    })
+})
+
+describe('db', () => {
+    
+    describe('getAllInstances', () => {
+        it('can access the rows on the users table', async () => {
+            const type = 'users';
+
+            const response = await db.getAllInstances(type);
+
+            assert.ok(response.rows);
+        })
+        it('can access the rows on the products table', async () => {
+            const type = 'products';
+
+            const response = await db.getAllInstances(type);
+
+            assert.ok(response.rows)
+        })
+    })
+
+    describe('getInstanceById', () => {
+        it('retrieves a user from the database with a matching id', () => {
+            
+
+        })
+
+    })
+
+    describe('addInstance', () => {
+        
+        it('adds a user to the database', async () => {
+            const type = 'users';
+            const model = userModel
+
+            const response = await db.addInstance(type, model);
+
+            assert.ok(response);
+        })
+    })
+})

--- a/database/db.test.js
+++ b/database/db.test.js
@@ -213,9 +213,19 @@ describe('db', () => {
             const expected = 999
 
             const response = await db.getInstanceById(type, id);
-            const actual = response.id;
+            const actual = response[0].cart_id;
             
             assert.equal(expected, actual);
+        })
+        it('retrieves a cart\'s contents from the database with a matching id', async () => {
+            const type = 'carts'
+            const id = 999
+            const expected = '999'
+
+            const response = await db.getInstanceById(type, id);
+            const actual = response[0].product_id;
+
+            assert.equal(actual, expected);
         })
         it('retrieves an order from the database with a matching id', async () => {
             const type = 'orders'
@@ -223,8 +233,18 @@ describe('db', () => {
             const expected = 999
 
             const response = await db.getInstanceById(type, id);
-            const actual = response.number;
+            const actual = response[0].order_number;
             
+            assert.equal(expected, actual);
+        })
+        it('retrieves an order\'s contents from the database with a matching id', async () => {
+            const type = 'orders'
+            const id = 999
+            const expected = '999'
+
+            const response = await db.getInstanceById(type, id);
+            const actual = response[0].product_id;
+
             assert.equal(expected, actual);
         })
         it('retrieves a products_carts row from the database with two a matching ids', async () => {

--- a/database/db.test.js
+++ b/database/db.test.js
@@ -2,29 +2,14 @@ const assert = require('assert');
 const db = require('./db');
 const query = require('./index.js');
 const util = require('./util.js');
-const formatDate = require('date-format');
-
-const date = new Date(2000, 1, 1, 1, 1, 1);
-const formattedDate = formatDate(date);
-const userModel = {
-    id: 999,
-    username: 'test_user_9999',
-    password: "ffffffffff",
-    first_name: 'test',
-    last_name: 'user',
-    street_address: '123 Anystreet',
-    city: 'Anytown',
-    state: 'USA',
-    zip: 99999,
-    date_created: formattedDate,
-    isAdmin: true
-}
-const productModel = {
-    id: 999,
-    name: 'Test Product',
-    img_path: '/test/path',
-    description: 'This is a description of a product.'
-}
+const {
+    cartModel,
+    orderModel,
+    userModel,
+    productModel,
+    productCartModel,
+    productOrderModel
+} = require('./mockModels.js');
 
 describe('query', () => {
     it('connects to the database', async () => {
@@ -40,7 +25,7 @@ describe('util', () => {
             const type = 'orders';
             const expected = 'number';
 
-            const actual = db.getIdString(type);
+            const actual = util.getIdString(type);
 
             assert.ok(expected == actual);
         })
@@ -56,6 +41,7 @@ describe('util', () => {
             assert.equal(expected, actual1);
             assert.equal(expected, actual2);
         })
+
 
     })
 
@@ -74,7 +60,7 @@ describe('util', () => {
         it('formats a products type into valid SQL values', () => {
             const type = 'products'
             const model = productModel;
-            const expected = "999, 'Test Product', '/test/path', 'This is a description of a product.'"
+            const expected = "'999', 'Test Product', '/test/path', 'This is a description of a product.'"
             
             const actual = util.formatValues(type, model);
 
@@ -85,6 +71,63 @@ describe('util', () => {
 
 describe('db', () => {
     
+    describe('addInstance', () => {
+        
+        it('adds a user to the database', async () => {
+            const type = 'users';
+            const model = userModel
+
+            const response = await db.addInstance(type, model);
+
+            assert.ok(response);
+        })
+
+        it('adds a product to the database', async () => {
+            const type = 'products';
+            const model = productModel
+            
+            const response = await db.addInstance(type, model);
+
+            assert.ok(response);
+        })
+
+        it('adds a cart to the database', async () => {
+            const type = 'carts';
+            const model = cartModel
+            
+            const response = await db.addInstance(type, model);
+
+            assert.ok(response);
+        })
+
+        it('adds an order to the databse', async () => {
+            const type = 'orders';
+            const model = orderModel;
+
+            const response = await db.addInstance(type, model);
+
+            assert.ok(response);
+        })
+
+        it('adds a products_carts row', async () => {
+            const type = 'products_carts'
+            const model = productCartModel;
+
+            const response = await db.addInstance(type, model);
+
+            assert.ok(response);
+        })
+
+        it('adds a products_orders row', async () => {
+            const type = 'products_orders'
+            const model = productOrderModel;
+
+            const response = await db.addInstance(type, model);
+
+            assert.ok(response);
+        })
+    })
+
     describe('getAllInstances', () => {
         it('can access the rows on the users table', async () => {
             const type = 'users';
@@ -102,23 +145,83 @@ describe('db', () => {
         })
     })
 
-    describe('getInstanceById', () => {
-        it('retrieves a user from the database with a matching id', () => {
+    describe('getInstanceById', async () => {
+        it('retrieves a user from the database with a matching id', async () => {
+            const type = 'users'
+            const id = 999
+            const expected = 999
+
+            const response = await db.getInstanceById(type, id);
+            const actual = response.id;
             
-
+            assert.equal(expected, actual);
         })
 
     })
 
-    describe('addInstance', () => {
-        
-        it('adds a user to the database', async () => {
-            const type = 'users';
-            const model = userModel
+    describe('removeInstanceById', async () => {
+        it('removes a product_order with two matching ids', async () => {
+            const type = 'products_orders'
+            const id = '999'
+            const secondaryId = 999
+            const expected = 'DELETE'
 
-            const response = await db.addInstance(type, model);
+            const response = await db.removeInstanceById(type, id, secondaryId);
+            const actual = response.command;
 
-            assert.ok(response);
+            assert.equal(expected, actual);
+        })
+        it('removes a product_cart with two matching ids', async () => {
+            const type = 'products_carts'
+            const id = '999'
+            const secondaryId = 999
+            const expected = 'DELETE'
+
+            const response = await db.removeInstanceById(type, id, secondaryId);
+            const actual = response.command;
+
+            assert.equal(expected, actual);
+        })
+        it('removes an order with a matching id', async () => {
+            const type = 'orders'
+            const id = 999
+            const expected = 'DELETE'
+
+            const response = await db.removeInstanceById(type, id);
+            const actual = response.command;
+
+            assert.equal(expected, actual);
+        })
+        it('removes a product with a matching id', async () => {
+            const type = 'products'
+            const id = '999'
+            const expected = 'DELETE'
+
+            const response = await db.removeInstanceById(type, id);
+            const actual = response.command;
+
+            assert.equal(expected, actual);
+        })
+        it('removes a cart with a matching id', async () => {
+            const type = 'carts'
+            const id = 999
+            const expected = 'DELETE'
+
+            const response = await db.removeInstanceById(type, id);
+            const actual = response.command;
+
+            assert.equal(expected, actual);
+        })
+        it('removes a user with a matching id', async () => {
+            const type = 'users'
+            const id = 999
+            const expected = 'DELETE'
+
+            const response = await db.removeInstanceById(type, id);
+            const actual = response.command;
+
+            assert.equal(expected, actual);
         })
     })
+
 })

--- a/database/db.test.js
+++ b/database/db.test.js
@@ -67,6 +67,47 @@ describe('util', () => {
             assert.equal(expected, actual);
         })
     })
+
+    describe('createWhereClause', () => {
+        it('creates a custom where clause for the products_orders type', () => {
+            const type = 'products_orders'
+            const id = '999'
+            const secondaryId = 999
+            const expected = "product_id = '999' AND order_number = 999";
+
+            const actual = util.createWhereClause(type, id, secondaryId)
+
+            assert.equal(expected, actual);
+        })
+        it('creates a custom where clause for the products_carts type', () => {
+            const type = 'products_carts'
+            const id = '999'
+            const secondaryId = 999
+            const expected = "product_id = '999' AND cart_id = 999";
+
+            const actual = util.createWhereClause(type, id, secondaryId)
+
+            assert.equal(expected, actual);
+        })
+        it('creates a custom where clause for the products type', () => {
+            const type = 'products'
+            const id = '999'
+            const expected = "id = '999'";
+
+            const actual = util.createWhereClause(type, id)
+
+            assert.equal(expected, actual);
+        })
+        it('returns id = {:id} for all others', () => {
+            const type = ''
+            const id = 999
+            const expected = "id = 999";
+
+            const actual = util.createWhereClause(type, id)
+
+            assert.equal(expected, actual);
+        })
+    })
 })
 
 describe('db', () => {
@@ -156,6 +197,16 @@ describe('db', () => {
             
             assert.equal(expected, actual);
         })
+        // it('retrieves a product from the database with a matching id', async () => {
+        //     const type = 'products'
+        //     const id = '999'
+        //     const expected = '999'
+
+        //     const response = await db.getInstanceById(type, id);
+        //     const actual = response.id;
+            
+        //     assert.equal(expected, actual);
+        // })
 
     })
 

--- a/database/index.js
+++ b/database/index.js
@@ -10,9 +10,8 @@ const pool = new Pool({
     database: process.env.DB_CONN
 });
 
-const query = async (text, params, callback) => {
-    const result = await pool.query(text, params, callback);
-    return result
+const query = (text, params, callback) => {
+    return pool.query(text, params, callback);
 }
 
 module.exports = query;

--- a/database/index.js
+++ b/database/index.js
@@ -1,0 +1,10 @@
+const pg = require('pg');
+const { Pool } = pg;
+
+const pool = new Pool();
+
+const db = (text, params, callback) => {
+    return pool.query(text, params, callback);
+}
+
+module.exports = db;

--- a/database/index.js
+++ b/database/index.js
@@ -1,10 +1,18 @@
 const pg = require('pg');
 const { Pool } = pg;
+require('dotenv').config();
 
-const pool = new Pool();
+const pool = new Pool({
+    user: process.env.DB_USER,
+    password: process.env.DB_PASS,
+    host: process.env.DB_HOST,
+    port: process.env.DB_PORT,
+    database: process.env.DB_CONN
+});
 
-const db = (text, params, callback) => {
-    return pool.query(text, params, callback);
+const query = async (text, params, callback) => {
+    const result = await pool.query(text, params, callback);
+    return result
 }
 
-module.exports = db;
+module.exports = query;

--- a/database/mockModels.js
+++ b/database/mockModels.js
@@ -5,7 +5,7 @@ const formattedDate = formatDate(date);
 
 const cartModel = {
     id: 999,
-    username: 'test_user_9999'
+    user_id: 999
 }
 
 const orderModel = {

--- a/database/mockModels.js
+++ b/database/mockModels.js
@@ -26,7 +26,7 @@ const userModel = {
     state: 'USA',
     zip: 99999,
     date_created: formattedDate,
-    isAdmin: true
+    isadmin: true
 }
 
 const productModel = {

--- a/database/mockModels.js
+++ b/database/mockModels.js
@@ -1,0 +1,56 @@
+const formatDate = require('date-format');
+
+const date = new Date(2000, 1, 1, 1, 1, 1);
+const formattedDate = formatDate(date);
+
+const cartModel = {
+    id: 999,
+    username: 'test_user_9999'
+}
+
+const orderModel = {
+    number: 999,
+    date_created: formattedDate,
+    status: 'Pending',
+    user_id: 999
+}
+
+const userModel = {
+    id: 999,
+    username: 'test_user_9999',
+    password: "ffffffffff",
+    first_name: 'test',
+    last_name: 'user',
+    street_address: '123 Anystreet',
+    city: 'Anytown',
+    state: 'USA',
+    zip: 99999,
+    date_created: formattedDate,
+    isAdmin: true
+}
+
+const productModel = {
+    id: '999',
+    name: 'Test Product',
+    img_path: '/test/path',
+    description: 'This is a description of a product.'
+}
+
+const productCartModel = {
+    product_id: '999',
+    cart_id: 999
+}
+
+const productOrderModel = {
+    product_id: '999',
+    order_id: 999
+}
+
+module.exports = {
+    cartModel,
+    orderModel,
+    userModel,
+    productModel,
+    productCartModel,
+    productOrderModel
+}

--- a/database/util.js
+++ b/database/util.js
@@ -1,12 +1,11 @@
 const getIdString = (type) => {
     if (type == 'orders') {
-        const str = 'number'
+        return 'number';
     } else if (type == 'products_orders' || type == 'products_carts') {
-        const str = 'product_id'
+        return 'product_id';
     } else {
-        const str = 'id'
+        return 'id';
     }
-    return str;
 }
 
 const modelSchema = {

--- a/database/util.js
+++ b/database/util.js
@@ -7,7 +7,7 @@ const getIdString = (type) => {
 }
 
 const modelSchema = {
-    carts: 'id, username',
+    carts: 'id, user_id',
     orders: 'number, date_created, status, user_id',
     products: 'id, name, img_path, description',
     users: 'id, username, password, first_name, last_name, street_address, city, state, zip, date_created, isadmin',

--- a/database/util.js
+++ b/database/util.js
@@ -1,0 +1,32 @@
+const getIdString = (type) => {
+    return type == 'orders' ? 'number' : 'id';
+}
+
+const modelSchema = {
+    cart: 'id, username',
+    orders: 'number, date_created, status, user_id',
+    products: 'id, name, img_path, description',
+    users: 'id, username, password, first_name, last_name, street_address, city, state, zip, date_created, isadmin',
+    products_carts: 'product_id, cart_id',
+    products_orders: 'product_id, order_number'
+}
+
+const formatValues = (type, model) => {
+    if (!modelSchema.hasOwnProperty(type)) {
+        throw new Error('Invalid Type');
+    }
+    const values = Object.values(model);
+    values.forEach((value, index) => {
+        if (typeof value == 'string') {
+            value = `'${value}'`
+            values[index] = value;
+        }
+    })
+    return values.join(', ');
+}
+
+module.exports = {
+    getIdString,
+    modelSchema,
+    formatValues
+}

--- a/database/util.js
+++ b/database/util.js
@@ -1,7 +1,7 @@
 const getIdString = (type) => {
     if (type == 'orders') {
         return 'number';
-    } else if (type == 'products_orders' || type == 'products_carts') {
+    } else if (type == 'products') {
         return 'product_id';
     } else {
         return 'id';

--- a/database/util.js
+++ b/database/util.js
@@ -1,9 +1,16 @@
 const getIdString = (type) => {
-    return type == 'orders' ? 'number' : 'id';
+    if (type == 'orders') {
+        const str = 'number'
+    } else if (type == 'products_orders' || type == 'products_carts') {
+        const str = 'product_id'
+    } else {
+        const str = 'id'
+    }
+    return str;
 }
 
 const modelSchema = {
-    cart: 'id, username',
+    carts: 'id, username',
     orders: 'number, date_created, status, user_id',
     products: 'id, name, img_path, description',
     users: 'id, username, password, first_name, last_name, street_address, city, state, zip, date_created, isadmin',

--- a/database/util.js
+++ b/database/util.js
@@ -1,8 +1,6 @@
 const getIdString = (type) => {
     if (type == 'orders') {
         return 'number';
-    } else if (type == 'products') {
-        return 'product_id';
     } else {
         return 'id';
     }

--- a/database/util.js
+++ b/database/util.js
@@ -29,8 +29,21 @@ const formatValues = (type, model) => {
     return values.join(', ');
 }
 
+const createWhereClause = (type, id, secondaryId) => {
+    if (type == 'products_orders') {
+        return `product_id = '${id}' AND order_number = ${secondaryId}`
+    } else if (type == 'products_carts') {
+        return `product_id = '${id}' AND cart_id = ${secondaryId}`
+    } else if (type == 'products') {
+        return `id = '${id}'`
+    } else {
+        return `${getIdString(type)} = ${id}`
+    }
+}
+
 module.exports = {
     getIdString,
     modelSchema,
-    formatValues
+    formatValues,
+    createWhereClause
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
+        "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "pg": "^8.12.0"
       },
@@ -236,6 +237,17 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ee-first": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
+        "date-format": "^4.0.14",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "pg": "^8.12.0"
       },
       "devDependencies": {
+        "mocha": "^10.4.0",
         "nodemon": "^3.1.3"
       }
     },
@@ -29,6 +31,39 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -41,6 +76,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -110,6 +151,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -136,6 +183,55 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -159,6 +255,35 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -198,12 +323,32 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "node_modules/date-format": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
+      "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-data-property": {
@@ -239,6 +384,15 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
@@ -254,6 +408,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -282,10 +442,31 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -365,6 +546,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -380,6 +586,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -403,6 +615,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
@@ -421,6 +642,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -431,6 +672,27 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gopd": {
@@ -497,6 +759,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -528,6 +799,17 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -563,6 +845,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -582,6 +873,70 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/media-typer": {
@@ -645,6 +1000,142 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.4.0.tgz",
+      "integrity": "sha512-eqhGB8JKapEYcC4ytX/xrzKforgEc3j1pGlAXVy3eRwrtAy5/nIfT1SvgGzfN0XZZxeLq0aQWkOUAmqIJiv+bA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "8.1.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/mocha/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mocha/node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/ms": {
@@ -739,12 +1230,60 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -912,6 +1451,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -944,6 +1492,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -1009,6 +1566,15 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
     },
     "node_modules/serve-static": {
       "version": "1.15.0",
@@ -1088,6 +1654,44 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
@@ -1173,12 +1777,104 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^4.19.2"
+        "express": "^4.19.2",
+        "pg": "^8.12.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.3"
@@ -739,6 +740,87 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
+    "node_modules/pg": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.12.0.tgz",
+      "integrity": "sha512-A+LHUSnwnxrnL/tZ+OLfqR1SxLN3c/pgDztZ47Rpbsd4jUytsTtwQo/TLPRzPJMp/1pbhYVhH9cuSZLAajNfjQ==",
+      "dependencies": {
+        "pg-connection-string": "^2.6.4",
+        "pg-pool": "^3.6.2",
+        "pg-protocol": "^1.6.1",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
+      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA=="
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
+      "integrity": "sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
+      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg=="
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -749,6 +831,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -945,6 +1062,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -1034,6 +1159,14 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A REST API for an eCommerce application.",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -24,11 +24,13 @@
   },
   "homepage": "https://github.com/nmiller15/codecademy-ecom-api#readme",
   "dependencies": {
+    "date-format": "^4.0.14",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "pg": "^8.12.0"
   },
   "devDependencies": {
+    "mocha": "^10.4.0",
     "nodemon": "^3.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/nmiller15/codecademy-ecom-api#readme",
   "dependencies": {
+    "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "pg": "^8.12.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "homepage": "https://github.com/nmiller15/codecademy-ecom-api#readme",
   "dependencies": {
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "pg": "^8.12.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.3"


### PR DESCRIPTION
# Postgres Branch

This branch adds database method that will allow for more readable code in the routing of the API. These database methods include:

+ *query* - not to be used directly within routing
  + send query text directly to postgres
  + test: connects to the database
+ *addInstance*
  + give a type and model and add that model to the database in the table specified by type 
  + 6 passing tests: adding to each table
+ *getAllInstances*
  + accesses all the records on a given table
  + 2 passing tests: users and products are the only tables that should need accessed in this way
+ *getInstanceById*
  + return one record using a matching id
  + returns products associated with a cart and an order as well
  + 9 passing tests
+ *updateInstanceById*
  + edits user and product records, all other edits will be add and delete from the many-to-many tables
  + 2 passing tests
+ *removeInstanceById*
  + removes any record from a table - does not handle dependent records
  + 6 passing tests